### PR TITLE
Use short hash for github releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.sha }}          
-          release_name: ${{ github.sha }}
+          tag_name: ${{ github.sha }} | cut -c1-7          
+          release_name: ${{ github.sha }} | cut -c1-7
           draft: false
           prerelease: false
 


### PR DESCRIPTION
Github releases can't have the full hash as tag